### PR TITLE
Download button only on computers

### DIFF
--- a/reed-family/src/Gallery.css
+++ b/reed-family/src/Gallery.css
@@ -61,3 +61,9 @@
 .custom-card {
     margin-top: 10px;
 }
+
+@media (max-width: 767px) {
+    .download-button {
+        display: none;
+    }
+}


### PR DESCRIPTION
Removes download button for gallery cards on mobile devices. When using button on mobile, it saves to files app instead of photos app. This way, user doesn't get confused and hit the button. They should instead hold the photo, where the mobile ui will allow them to save to photos